### PR TITLE
build: add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/


### PR DESCRIPTION
In this PR you will find: 
- .idea folder .gitignored to allow contribute also without pycharm and keep the codebase clean